### PR TITLE
fix(button): prevent unnecessary paints of button icon

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -74,20 +74,17 @@ class FxABrowserFeature {
   }
 
   async updateState() {
-
     // The stored sessionToken will always be the source of truth when checking
     // account state.
     const user = await browser.fxa.getSignedInUser();
-    if (!user) {
+    if (user) {
+      if (user.verified) {
+        this.verifiedUser(user);
+      } else {
+        this.unverifiedUser();
+      }
+    } else {
       this.noUser();
-    }
-
-    if (user && !user.verified) {
-      this.unverifiedUser();
-    }
-
-    if (user && user.verified) {
-      this.verifiedUser(user);
     }
   }
 

--- a/src/feature.js
+++ b/src/feature.js
@@ -1,5 +1,14 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "(feature)" }]*/
 
+const DEFAULT_AVATAR = 0;
+const UNVERIFIED_AVATAR = 1;
+const USER_AVATAR = 2;
+
+const STANDARD_AVATARS = {
+  [DEFAULT_AVATAR]: "icons/avatar.svg",
+  [UNVERIFIED_AVATAR]: "icons/avatar_confirm.svg",
+};
+
 /**  Example Feature module for a Shield Study.
  *
  *  UI:
@@ -70,53 +79,52 @@ class FxABrowserFeature {
     // account state.
     const user = await browser.fxa.getSignedInUser();
     if (!user) {
-      this._noUser();
+      this.noUser();
     }
 
     if (user && !user.verified) {
-      this._unverifiedUser();
+      this.unverifiedUser();
     }
 
     if (user && user.verified) {
-      this._verifiedUser(user);
+      this.verifiedUser(user);
     }
   }
 
-  _noUser() {
-    this._defaultAvatar();
-    browser.browserAction.setIcon({ path: "icons/avatar.svg" });
+  noUser() {
+    this.standardAvatar(DEFAULT_AVATAR);
     browser.browserAction.setPopup({ popup: "popup/sign_in/sign_in.html" });
   }
 
-  _unverifiedUser() {
-    this._defaultAvatar();
-    browser.browserAction.setIcon({ path: "icons/avatar_confirm.svg" });
+  standardAvatar(id) {
+    this._avatarUrl = null;
+    if (this._avatar !== id) {
+      this._avatar = id;
+      browser.browserAction.setIcon({ path: STANDARD_AVATARS[id] });
+    }
+  }
+
+  unverifiedUser() {
+    this.standardAvatar(UNVERIFIED_AVATAR);
     browser.browserAction.setPopup({ popup: "popup/unverified/unverified.html" });
   }
 
-  _verifiedUser(user) {
-    if (!user || user.avatarDefault) {
-      this._defaultAvatar();
+  verifiedUser(user) {
+    if (user.avatarDefault) {
+      this.standardAvatar(DEFAULT_AVATAR);
     } else {
-      this._userAvatar(user.avatar);
+      this.userAvatar(user.avatar);
     }
 
     browser.browserAction.setPopup({ popup: "popup/menu/menu.html" });
   }
 
-  _defaultAvatar() {
-    if (this._avatar) {
-      this._avatar = null;
-    }
-    // TODO We should also handle rendering first letter of email as the avatar in here.
-    browser.browserAction.setIcon({ path: "icons/avatar.svg" });
-  }
-
-  _userAvatar(url) {
-    if (this._avatar && this._avatarUrl === url) {
+  userAvatar(url) {
+    if (this._avatar === USER_AVATAR && this._avatarUrl === url) {
       return;
     }
 
+    this._avatar = USER_AVATAR;
     this._avatarUrl = url;
 
     const img = new Image();
@@ -135,9 +143,9 @@ class FxABrowserFeature {
 
       ctx.drawImage(this, 0, 0);
 
-      this._avatar = ctx.getImageData(0, 0, 200, 200);
+      const imageData = ctx.getImageData(0, 0, 200, 200);
 
-      browser.browserAction.setIcon({ imageData: this._avatar });
+      browser.browserAction.setIcon({ imageData });
     };
     img.src = url;
   }

--- a/src/feature.js
+++ b/src/feature.js
@@ -107,10 +107,10 @@ class FxABrowserFeature {
   }
 
   verifiedUser(user) {
-    if (user.avatarDefault) {
-      this.standardAvatar(DEFAULT_AVATAR);
-    } else {
+    if (user.avatar) {
       this.userAvatar(user.avatar);
+    } else {
+      this.standardAvatar(DEFAULT_AVATAR);
     }
 
     browser.browserAction.setPopup({ popup: "popup/menu/menu.html" });


### PR DESCRIPTION
Fixes #19.

The main fix here, d262c0c, ensures that we only paint the button icon when it changes and we stop painting it multiple times per profile-update.

I also included two smaller, kind-of-related changes:

* In b7813f7, I tweaked the conditional code in `updateState` to be cleaner. Previously it was leading with a negative condition, which is harder for a reader to grok. But also, instead of using `else` or `return` to control the flow, it was re-asserting the negation of the earlier condition in later ones. So I flipped it round to lead with the positive condition and then use `else` for control flow.

* While testing, I noticed that some calls to `userAvatar` were being made with a `null` value for `url`. I fixed that in 732817a by flipping the conditions in `verifiedUser` so that we only make the call to `userAvatar` when `user.avatar` is set.

@vbudhram r?