### PR TITLE
fix(icon): use a context-fill svg for browserAction icon

### DIFF
--- a/src/icons/avatar.svg
+++ b/src/icons/avatar.svg
@@ -2,6 +2,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg data-name="profile-active" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <path fill="#525252"
-          d="M8 1a7 7 0 1 0 7 7 7 7 0 0 0-7-7zm0 2a3 3 0 1 1-3 3 3 3 0 0 1 3-3zm4.11 7.81a5 5 0 0 1-8.22 0A1 1 0 0 1 4 9.58C5 8.36 6.48 10 8 10s3-1.64 4.05-.42a1 1 0 0 1 .06 1.23z"/>
+  <path fill="context-fill" fill-opacity="context-fill-opacity" fill-rule="evenodd"
+        d="M8 1a7 7 0 1 0 7 7 7 7 0 0 0-7-7zm0 2a3 3 0 1 1-3 3 3 3 0 0 1 3-3zm4.11 7.81a5 5 0 0 1-8.22 0A1 1 0 0 1 4 9.58C5 8.36 6.48 10 8 10s3-1.64 4.05-.42a1 1 0 0 1 .06 1.23z"/>
 </svg>

--- a/src/icons/avatar_confirm.svg
+++ b/src/icons/avatar_confirm.svg
@@ -2,9 +2,10 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg data-name="profile-confirm" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-    <path fill="#525252"
-          d="M14.92 9A6.63 6.63 0 0 0 15 8a7 7 0 1 0-7 7v-2a4.94 4.94 0 0 1-4.11-2.19A1 1 0 0 1 4 9.58C5 8.36 6.48 10 8 10h.09A1.51 1.51 0 0 1 9.5 9zM8 9a3 3 0 1 1 3-3 3 3 0 0 1-3 3z"/>
-    <path fill="#525252" d="M15.5 10h-6a.5.5 0 0 0-.5.5v.32l3.5 2.1 3.5-2.1v-.32a.5.5 0 0 0-.5-.5z"/>
-    <path fill="#525252"
-          d="M12.5 14a.48.48 0 0 1-.26-.07L9 12v3.5a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 .5-.5V12l-3.24 1.95a.48.48 0 0 1-.26.05z"/>
+  <path fill="context-fill" fill-opacity="context-fill-opacity" fill-rule="evenodd"
+        d="M14.92 9A6.63 6.63 0 0 0 15 8a7 7 0 1 0-7 7v-2a4.94 4.94 0 0 1-4.11-2.19A1 1 0 0 1 4 9.58C5 8.36 6.48 10 8 10h.09A1.51 1.51 0 0 1 9.5 9zM8 9a3 3 0 1 1 3-3 3 3 0 0 1-3 3z"/>
+  <path fill="context-fill" fill-opacity="context-fill-opacity" fill-rule="evenodd"
+        d="M15.5 10h-6a.5.5 0 0 0-.5.5v.32l3.5 2.1 3.5-2.1v-.32a.5.5 0 0 0-.5-.5z"/>
+  <path fill="context-fill" fill-opacity="context-fill-opacity" fill-rule="evenodd"
+        d="M12.5 14a.48.48 0 0 1-.26-.07L9 12v3.5a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 .5-.5V12l-3.24 1.95a.48.48 0 0 1-.26.05z"/>
 </svg>


### PR DESCRIPTION
From https://github.com/mozilla/notes/pull/811, updated default avatar svg to be context filled so that it gets browser theme color. We won't be able to test this until we get a signed version of the extension since it is only available to signed extensions.

Fixes https://github.com/mozilla/fxa-discoverability-shield-study/issues/35