### PR TITLE
fix(settings): hide add-on in about:addons

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
     }
   },
   "default_locale": "en-US",
+  "hidden": true,
   "experiment_apis": {
     "fxa": {
       "schema": "./privileged/fxa/schema.json",


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-discoverability-shield-study/issues/48.

This is based off the solution at https://github.com/mozilla/side-view/issues/385, which adds the `hidden=true`. Unfortunately, I believe this will require a signed extension to test and verify.