### PR TITLE
fix(metrics): correctly set `sendtab` when opening survey

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global getStudySetup, feature */
 
 /**

--- a/src/feature.js
+++ b/src/feature.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "(feature)" }]*/
 
 const DEFAULT_AVATAR = 0;

--- a/src/popup/fxa.js
+++ b/src/popup/fxa.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 const ENTRYPOINT_BASE = "fxa_discoverability_v2";

--- a/src/popup/fxa.js
+++ b/src/popup/fxa.js
@@ -106,9 +106,9 @@ async function createNewTab(url) {
 
   // On send tab clicks, set a session property that the user clicked the link.
   // When the experiment ends, this value will get appended to the survey.
-  if (url === SEND_TAB_INFO) {
+  if (url.indexOf(SEND_TAB_INFO) > -1) {
     const tab = await browser.storage.local.get("sendTab");
-    if (!!tab.sendTab) {
+    if (!tab.sendTab) {
       browser.storage.local.set({
         "sendTab": true,
       });

--- a/src/privileged/fxa/api.js
+++ b/src/privileged/fxa/api.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 /* global ExtensionAPI */

--- a/src/privileged/testingOverrides/api.js
+++ b/src/privileged/testingOverrides/api.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 /* global ExtensionAPI, Preferences */

--- a/src/privileged/testingOverrides/stubApi.js
+++ b/src/privileged/testingOverrides/stubApi.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint-disable */
 
 ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");

--- a/src/studySetup.js
+++ b/src/studySetup.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "getStudySetup" }]*/
 
 /**


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-discoverability-shield-study/issues/66
Fixes #20 

This bug was introduced while supporting different entrypoint for the different variations in phase 2. It now correctly checks url and sets the local storage property if the `Send tab To Device` link was clicked.

I also took this opportunity to add the MLP to source files.

@philbooth r?